### PR TITLE
Ctrl+Space の全角スペース入力を config.toml で切替可能にする

### DIFF
--- a/docs/superpowers/plans/2026-07-01-configurable-ctrl-space.md
+++ b/docs/superpowers/plans/2026-07-01-configurable-ctrl-space.md
@@ -1,0 +1,415 @@
+# Configurable Ctrl+Space Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `config.toml` の設定で、Ctrl+Space を全角スペース入力に使うか OS へ素通しするかを切り替えられるようにする。
+
+**Architecture:** 既存の設定伝搬経路（`config.toml` → `Settings` → `EngineConfig` → エンジンのキー処理）に新しいブール設定 `keys.ctrl_space_fullwidth` を1つ追加する。エンジンの `input.rs` で Empty / Composing 両状態の Ctrl+Space 分岐にこのフラグのチェックを入れ、false なら `not_consumed` を返す。`not_consumed` を返せばフロント（macOS Swift / Linux fcitx5）が自動で OS へキーを素通しするため、フロント側は無変更。
+
+**Tech Stack:** Rust (Cargo workspace crate `karukan-im`)、TOML 設定、`cargo test`。
+
+## Global Constraints
+
+- 変更は `karukan-im` クレートのみ。フロントエンド（Swift / C++）は変更しない。
+- デフォルト値は `true`（既存挙動を維持し後方互換を保つ）。
+- 設定セクション名は `[keys]`、キー名は `ctrl_space_fullwidth`（bool）。
+- Rust では可能な限り関数型スタイルを優先するが、既存の `match` によるキー処理パターンには合わせる。
+- テストは各タスク内で TDD（Red → Green）で書く。コミットはこのリポジトリの規約に従い `git ai-commit` を使う（`git commit` を直接使わない）。
+
+## File Structure
+
+- `karukan-im/config/default.toml` — 埋め込みデフォルト設定。`[keys]` セクションを追加。
+- `karukan-im/src/config/settings.rs` — `KeysSettings` 構造体と `Settings.keys` フィールド、読み込みテスト。
+- `karukan-im/src/core/engine/types.rs` — `EngineConfig` に `ctrl_space_fullwidth` を追加、`from_settings` と `Default` に反映。
+- `karukan-im/src/core/engine/input.rs` — `process_key_empty` と `process_key_composing` の Ctrl+Space 分岐にフラグチェックを追加。
+- `karukan-im/src/core/engine/tests/basic.rs` — `EngineConfig` のデフォルト/マッピングと、Empty/Composing のキー挙動テスト。
+
+すべて既存ファイルへの追記・修正。新規ファイルなし。
+
+---
+
+### Task 1: `KeysSettings` を設定に追加する
+
+**Files:**
+- Modify: `karukan-im/config/default.toml`
+- Modify: `karukan-im/src/config/settings.rs`
+- Test: `karukan-im/src/config/settings.rs`（同ファイル内の `#[cfg(test)] mod tests`）
+
+**Interfaces:**
+- Produces: `pub struct KeysSettings { pub ctrl_space_fullwidth: bool }`、`Settings.keys: KeysSettings`。Task 2 の `EngineConfig::from_settings` が `settings.keys.ctrl_space_fullwidth` を参照する。
+
+備考：`Settings::default()` は埋め込み `default.toml` をパースして生成されるため、`[keys]` セクションを `default.toml` に追加してからでないと `Settings::default()` が panic する。したがって default.toml と settings.rs は同一タスクで変更する。ユーザー設定に `[keys]` が無い場合は `parse_with_defaults` の `merge_toml` がデフォルト値で埋めるので、serde の default 属性は不要（既存の `ConversionSettings` と同じ扱い）。
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`karukan-im/src/config/settings.rs` の `mod tests`（`test_partial_config` の隣、末尾付近）に追記：
+
+```rust
+    #[test]
+    fn test_keys_default_ctrl_space_fullwidth() {
+        let settings = Settings::default();
+        assert!(settings.keys.ctrl_space_fullwidth);
+    }
+
+    #[test]
+    fn test_keys_override_and_other_sections_keep_defaults() {
+        let mut file = NamedTempFile::new().unwrap();
+        writeln!(
+            file,
+            r#"
+[keys]
+ctrl_space_fullwidth = false
+"#
+        )
+        .unwrap();
+
+        let path = file.path().to_path_buf();
+        let settings = Settings::load_from(&path).unwrap();
+        assert!(!settings.keys.ctrl_space_fullwidth);
+        // Sections the user did not specify still fall back to defaults.
+        assert_eq!(settings.conversion.num_candidates, 9);
+    }
+```
+
+- [ ] **Step 2: テストが失敗することを確認**
+
+Run: `cargo test -p karukan-im test_keys_ 2>&1 | tail -20`
+Expected: コンパイルエラー（`Settings` に `keys` フィールドが無い / `KeysSettings` 未定義）で FAIL。
+
+- [ ] **Step 3: 最小実装**
+
+`karukan-im/src/config/settings.rs` の `Settings` 構造体にフィールドを追加：
+
+```rust
+/// Configuration settings for the IME
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Settings {
+    /// Conversion settings
+    pub conversion: ConversionSettings,
+    /// Learning cache settings
+    pub learning: LearningSettings,
+    /// Key-binding behavior settings
+    pub keys: KeysSettings,
+}
+```
+
+`LearningSettings` の定義の直後に `KeysSettings` を追加：
+
+```rust
+/// Key-binding behavior settings
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct KeysSettings {
+    /// Use Ctrl+Space to input a full-width space (U+3000).
+    /// When false, Karukan does not intercept Ctrl+Space and lets it pass
+    /// through to the OS (so window-switching shortcuts etc. still work).
+    pub ctrl_space_fullwidth: bool,
+}
+```
+
+`karukan-im/config/default.toml` の末尾（`[learning]` セクションの後）に追記：
+
+```toml
+
+[keys]
+# Ctrl+Space を全角スペース入力に使う。
+# false にすると Karukan は Ctrl+Space を横取りせず OS に渡す
+# （macOS/Linux のウインドウ切替などのショートカットが効くようになる）。
+ctrl_space_fullwidth = true
+```
+
+- [ ] **Step 4: テストが通ることを確認**
+
+Run: `cargo test -p karukan-im test_keys_ 2>&1 | tail -20`
+Expected: `test_keys_default_ctrl_space_fullwidth` と `test_keys_override_and_other_sections_keep_defaults` が PASS。
+
+- [ ] **Step 5: 既存の設定テストが壊れていないことを確認**
+
+Run: `cargo test -p karukan-im --lib config 2>&1 | tail -20`
+Expected: 既存の `test_default_settings` / `test_partial_config` 等を含め全て PASS。
+
+- [ ] **Step 6: コミット**
+
+```bash
+git add karukan-im/config/default.toml karukan-im/src/config/settings.rs
+git ai-commit
+```
+
+---
+
+### Task 2: `EngineConfig` にフラグを追加し設定から反映する
+
+**Files:**
+- Modify: `karukan-im/src/core/engine/types.rs`
+- Test: `karukan-im/src/core/engine/tests/basic.rs`
+
+**Interfaces:**
+- Consumes: Task 1 の `Settings.keys.ctrl_space_fullwidth`。
+- Produces: `EngineConfig.ctrl_space_fullwidth: bool`。Task 3 / Task 4 が `self.config.ctrl_space_fullwidth` として読む。`EngineConfig::default()` は `true` を返す。
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`karukan-im/src/core/engine/tests/basic.rs` の末尾に追記：
+
+```rust
+#[test]
+fn ctrl_space_fullwidth_defaults_true_in_engine_config() {
+    let config = EngineConfig::default();
+    assert!(config.ctrl_space_fullwidth);
+}
+
+#[test]
+fn ctrl_space_fullwidth_maps_from_settings() {
+    let mut settings = crate::config::Settings::default();
+    assert!(EngineConfig::from_settings(&settings).ctrl_space_fullwidth);
+    settings.keys.ctrl_space_fullwidth = false;
+    assert!(!EngineConfig::from_settings(&settings).ctrl_space_fullwidth);
+}
+```
+
+- [ ] **Step 2: テストが失敗することを確認**
+
+Run: `cargo test -p karukan-im ctrl_space_fullwidth_ 2>&1 | tail -20`
+Expected: コンパイルエラー（`EngineConfig` に `ctrl_space_fullwidth` フィールドが無い）で FAIL。
+
+- [ ] **Step 3: 最小実装**
+
+`karukan-im/src/core/engine/types.rs` の `EngineConfig` 構造体（`pub live_conversion: bool,` の後）にフィールドを追加：
+
+```rust
+    /// Whether Ctrl+Space inputs a full-width space (U+3000).
+    /// When false, Ctrl+Space is not consumed and passes through to the OS.
+    pub ctrl_space_fullwidth: bool,
+```
+
+`EngineConfig::from_settings`（`live_conversion: settings.conversion.live_conversion,` の後）に追加：
+
+```rust
+            ctrl_space_fullwidth: settings.keys.ctrl_space_fullwidth,
+```
+
+`impl Default for EngineConfig`（`live_conversion: false,` の後）に追加：
+
+```rust
+            ctrl_space_fullwidth: true,
+```
+
+- [ ] **Step 4: テストが通ることを確認**
+
+Run: `cargo test -p karukan-im ctrl_space_fullwidth_ 2>&1 | tail -20`
+Expected: 両テストが PASS。
+
+- [ ] **Step 5: クレート全体がビルドできることを確認**
+
+Run: `cargo build -p karukan-im 2>&1 | tail -20`
+Expected: エラーなし（`with_config` を使う既存テストの構造体リテラルは `..EngineConfig::default()` を使っているため影響なし）。
+
+- [ ] **Step 6: コミット**
+
+```bash
+git add karukan-im/src/core/engine/types.rs karukan-im/src/core/engine/tests/basic.rs
+git ai-commit
+```
+
+---
+
+### Task 3: Empty 状態の Ctrl+Space をフラグで分岐する
+
+**Files:**
+- Modify: `karukan-im/src/core/engine/input.rs`（`process_key_empty`）
+- Test: `karukan-im/src/core/engine/tests/basic.rs`
+
+**Interfaces:**
+- Consumes: Task 2 の `self.config.ctrl_space_fullwidth`。
+- Produces: なし（挙動の変更のみ）。
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`karukan-im/src/core/engine/tests/basic.rs` の末尾に追記。`press_ctrl` は `tests/mod.rs` で定義済み（`use super::*` で利用可能）：
+
+```rust
+#[test]
+fn ctrl_space_inputs_fullwidth_space_in_empty_when_enabled() {
+    // Default config has ctrl_space_fullwidth = true.
+    let mut engine = InputMethodEngine::new();
+    let result = engine.process_key(&press_ctrl(Keysym::SPACE));
+    assert!(result.consumed);
+    assert!(matches!(engine.state(), InputState::Composing { .. }));
+    assert_eq!(engine.preedit().unwrap().text(), "\u{3000}");
+}
+
+#[test]
+fn ctrl_space_passes_through_in_empty_when_disabled() {
+    let config = EngineConfig {
+        ctrl_space_fullwidth: false,
+        ..EngineConfig::default()
+    };
+    let mut engine = InputMethodEngine::with_config(config);
+    let result = engine.process_key(&press_ctrl(Keysym::SPACE));
+    assert!(!result.consumed);
+    assert!(matches!(engine.state(), InputState::Empty));
+    assert!(
+        result.actions.is_empty(),
+        "expected no actions, got {:?}",
+        result.actions
+    );
+}
+```
+
+- [ ] **Step 2: テストが失敗することを確認**
+
+Run: `cargo test -p karukan-im ctrl_space_passes_through_in_empty 2>&1 | tail -20`
+Expected: `ctrl_space_passes_through_in_empty_when_disabled` が FAIL（現状は無効化フラグを見ずに全角スペースを consume するため `result.consumed` が true になり assert 失敗）。`ctrl_space_inputs_fullwidth_space_in_empty_when_enabled` は既存挙動なので PASS。
+
+- [ ] **Step 3: 最小実装**
+
+`karukan-im/src/core/engine/input.rs` の `process_key_empty` 冒頭の Ctrl+Space ブロックを次に置き換える：
+
+```rust
+        // Ctrl+Space: start input with full-width space.
+        // Gated on config: when `ctrl_space_fullwidth` is false, do not
+        // intercept — return not_consumed so the key passes through to the
+        // OS (e.g. window-switching shortcuts).
+        if key.modifiers.control_key && key.keysym == Keysym::SPACE {
+            if !self.config.ctrl_space_fullwidth {
+                return EngineResult::not_consumed();
+            }
+            self.converters.romaji.reset();
+            self.input_buf.clear();
+            self.input_buf.insert("\u{3000}");
+            let preedit = self.set_composing_state();
+            return EngineResult::consumed()
+                .with_action(EngineAction::UpdatePreedit(preedit))
+                .with_action(EngineAction::UpdateAuxText(self.format_aux_composing()));
+        }
+```
+
+- [ ] **Step 4: テストが通ることを確認**
+
+Run: `cargo test -p karukan-im ctrl_space 2>&1 | tail -20`
+Expected: Task 2・Task 3 の Ctrl+Space 関連テストが全て PASS。
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add karukan-im/src/core/engine/input.rs karukan-im/src/core/engine/tests/basic.rs
+git ai-commit
+```
+
+---
+
+### Task 4: Composing 状態の Ctrl+Space をフラグで分岐する
+
+**Files:**
+- Modify: `karukan-im/src/core/engine/input.rs`（`process_key_composing`）
+- Test: `karukan-im/src/core/engine/tests/basic.rs`
+
+**Interfaces:**
+- Consumes: Task 2 の `self.config.ctrl_space_fullwidth`。
+- Produces: なし（挙動の変更のみ）。
+
+注意：`process_key_composing` では、フラグ false のとき **明示的に `not_consumed` を返す**必要がある。単に全角スペース分岐をスキップすると、下の `match` の `Keysym::SPACE | Keysym::DOWN => self.start_conversion(false)` に該当し、Ctrl+Space が変換トリガーとして誤消費される。テストの `ctrl_space_passes_through_while_composing_when_disabled` がこのガードを検証する。
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`karukan-im/src/core/engine/tests/basic.rs` の末尾に追記：
+
+```rust
+#[test]
+fn ctrl_space_inserts_fullwidth_space_while_composing_when_enabled() {
+    let mut engine = InputMethodEngine::new();
+    engine.process_key(&press('a')); // preedit "あ", Composing
+    let result = engine.process_key(&press_ctrl(Keysym::SPACE));
+    assert!(result.consumed);
+    assert!(matches!(engine.state(), InputState::Composing { .. }));
+    assert!(
+        engine.input_buf.text.contains('\u{3000}'),
+        "buffer should contain a full-width space, got {:?}",
+        engine.input_buf.text
+    );
+}
+
+#[test]
+fn ctrl_space_passes_through_while_composing_when_disabled() {
+    let config = EngineConfig {
+        ctrl_space_fullwidth: false,
+        ..EngineConfig::default()
+    };
+    let mut engine = InputMethodEngine::with_config(config);
+    engine.process_key(&press('a')); // preedit "あ", Composing
+    let result = engine.process_key(&press_ctrl(Keysym::SPACE));
+    assert!(!result.consumed);
+    // Must NOT trigger conversion (the fall-through bug guard) and must
+    // NOT insert a full-width space.
+    assert!(matches!(engine.state(), InputState::Composing { .. }));
+    assert_eq!(engine.preedit().unwrap().text(), "あ");
+    assert!(!engine.input_buf.text.contains('\u{3000}'));
+}
+```
+
+- [ ] **Step 2: テストが失敗することを確認**
+
+Run: `cargo test -p karukan-im ctrl_space_passes_through_while_composing 2>&1 | tail -20`
+Expected: `ctrl_space_passes_through_while_composing_when_disabled` が FAIL（現状は全角スペースを挿入し `result.consumed` が true になる、または変換トリガーで Conversion 状態になり assert 失敗）。
+
+- [ ] **Step 3: 最小実装**
+
+`karukan-im/src/core/engine/input.rs` の `process_key_composing` の Ctrl 分岐内、`Keysym::SPACE` のアームを次に置き換える：
+
+```rust
+                // Ctrl+Space: insert full-width space (U+3000), unless
+                // disabled in config — then pass through to the OS. Must
+                // return explicitly here: falling through would let the
+                // bare-Space arm below treat Ctrl+Space as the conversion
+                // trigger.
+                Keysym::SPACE => {
+                    return if self.config.ctrl_space_fullwidth {
+                        self.input_fullwidth_space()
+                    } else {
+                        EngineResult::not_consumed()
+                    };
+                }
+```
+
+- [ ] **Step 4: テストが通ることを確認**
+
+Run: `cargo test -p karukan-im ctrl_space 2>&1 | tail -20`
+Expected: Ctrl+Space 関連テストが全て PASS。
+
+- [ ] **Step 5: クレート全体のテスト・lint を確認**
+
+Run: `cargo test -p karukan-im 2>&1 | tail -20`
+Expected: 全テスト PASS。
+
+Run: `cargo clippy -p karukan-im 2>&1 | tail -20`
+Expected: 新しい警告なし。
+
+Run: `cargo fmt --all -- --check 2>&1 | tail -5`
+Expected: 差分なし（差分があれば `cargo fmt --all` を実行してから再コミット）。
+
+- [ ] **Step 6: コミット**
+
+```bash
+git add karukan-im/src/core/engine/input.rs karukan-im/src/core/engine/tests/basic.rs
+git ai-commit
+```
+
+---
+
+## Manual Verification（実装完了後、任意）
+
+実機での動作確認は以下（コード変更不要のフロント経由で確認できる）：
+
+1. `~/Library/Application Support/com.karukan.karukan-im/config.toml`（macOS）または `~/.config/karukan-im/config.toml`（Linux）に以下を書く：
+   ```toml
+   [keys]
+   ctrl_space_fullwidth = false
+   ```
+2. macOS は `killall KarukanIME`、Linux は fcitx5 を再起動して imserver / アドオンに設定を読み直させる。
+3. Karukan 入力モードで、未入力時に Ctrl+Space を押し、全角スペースが入らず OS のウインドウ切替ショートカットが発火することを確認する。
+4. `true` に戻す（または行を消す）と全角スペースが入る従来挙動に戻ることを確認する。
+
+## Self-Review
+
+- **Spec coverage:** 設定項目（Task 1）、伝搬経路（Task 2）、Empty 分岐（Task 3）、Composing 分岐 + 誤消費ガード（Task 4）、テスト4ケース + 設定テスト、フロント無変更、デフォルト true をすべてタスク化済み。副作用（Composing 中の preedit 残存）は spec に記載済みで実装上の対応不要。
+- **Placeholder scan:** プレースホルダなし。全ステップに実コードと実コマンドを記載。
+- **Type consistency:** `KeysSettings.ctrl_space_fullwidth`（Task 1）→ `EngineConfig.ctrl_space_fullwidth`（Task 2）→ `self.config.ctrl_space_fullwidth`（Task 3/4）で名称一致。`EngineConfig::default()` は Task 2 で `true` を設定し、Task 3/4 のテストが `InputMethodEngine::new()`（内部で `EngineConfig::default()` 使用）に依存する点も整合。

--- a/docs/superpowers/plans/2026-07-01-configurable-ctrl-space.md
+++ b/docs/superpowers/plans/2026-07-01-configurable-ctrl-space.md
@@ -18,11 +18,11 @@
 
 ## File Structure
 
-- `karukan-im/config/default.toml` — 埋め込みデフォルト設定。`[keys]` セクションを追加。
-- `karukan-im/src/config/settings.rs` — `KeysSettings` 構造体と `Settings.keys` フィールド、読み込みテスト。
-- `karukan-im/src/core/engine/types.rs` — `EngineConfig` に `ctrl_space_fullwidth` を追加、`from_settings` と `Default` に反映。
-- `karukan-im/src/core/engine/input.rs` — `process_key_empty` と `process_key_composing` の Ctrl+Space 分岐にフラグチェックを追加。
-- `karukan-im/src/core/engine/tests/basic.rs` — `EngineConfig` のデフォルト/マッピングと、Empty/Composing のキー挙動テスト。
+- `karukan-im/core/config/default.toml` — 埋め込みデフォルト設定。`[keys]` セクションを追加。
+- `karukan-im/core/src/config/settings.rs` — `KeysSettings` 構造体と `Settings.keys` フィールド、読み込みテスト。
+- `karukan-im/core/src/core/engine/types.rs` — `EngineConfig` に `ctrl_space_fullwidth` を追加、`from_settings` と `Default` に反映。
+- `karukan-im/core/src/core/engine/input.rs` — `process_key_empty` と `process_key_composing` の Ctrl+Space 分岐にフラグチェックを追加。
+- `karukan-im/core/src/core/engine/tests/basic.rs` — `EngineConfig` のデフォルト/マッピングと、Empty/Composing のキー挙動テスト。
 
 すべて既存ファイルへの追記・修正。新規ファイルなし。
 
@@ -31,9 +31,9 @@
 ### Task 1: `KeysSettings` を設定に追加する
 
 **Files:**
-- Modify: `karukan-im/config/default.toml`
-- Modify: `karukan-im/src/config/settings.rs`
-- Test: `karukan-im/src/config/settings.rs`（同ファイル内の `#[cfg(test)] mod tests`）
+- Modify: `karukan-im/core/config/default.toml`
+- Modify: `karukan-im/core/src/config/settings.rs`
+- Test: `karukan-im/core/src/config/settings.rs`（同ファイル内の `#[cfg(test)] mod tests`）
 
 **Interfaces:**
 - Produces: `pub struct KeysSettings { pub ctrl_space_fullwidth: bool }`、`Settings.keys: KeysSettings`。Task 2 の `EngineConfig::from_settings` が `settings.keys.ctrl_space_fullwidth` を参照する。
@@ -42,7 +42,7 @@
 
 - [ ] **Step 1: 失敗するテストを書く**
 
-`karukan-im/src/config/settings.rs` の `mod tests`（`test_partial_config` の隣、末尾付近）に追記：
+`karukan-im/core/src/config/settings.rs` の `mod tests`（`test_partial_config` の隣、末尾付近）に追記：
 
 ```rust
     #[test]
@@ -78,7 +78,7 @@ Expected: コンパイルエラー（`Settings` に `keys` フィールドが無
 
 - [ ] **Step 3: 最小実装**
 
-`karukan-im/src/config/settings.rs` の `Settings` 構造体にフィールドを追加：
+`karukan-im/core/src/config/settings.rs` の `Settings` 構造体にフィールドを追加：
 
 ```rust
 /// Configuration settings for the IME
@@ -106,7 +106,7 @@ pub struct KeysSettings {
 }
 ```
 
-`karukan-im/config/default.toml` の末尾（`[learning]` セクションの後）に追記：
+`karukan-im/core/config/default.toml` の末尾（`[learning]` セクションの後）に追記：
 
 ```toml
 
@@ -130,7 +130,7 @@ Expected: 既存の `test_default_settings` / `test_partial_config` 等を含め
 - [ ] **Step 6: コミット**
 
 ```bash
-git add karukan-im/config/default.toml karukan-im/src/config/settings.rs
+git add karukan-im/core/config/default.toml karukan-im/core/src/config/settings.rs
 git ai-commit
 ```
 
@@ -139,8 +139,8 @@ git ai-commit
 ### Task 2: `EngineConfig` にフラグを追加し設定から反映する
 
 **Files:**
-- Modify: `karukan-im/src/core/engine/types.rs`
-- Test: `karukan-im/src/core/engine/tests/basic.rs`
+- Modify: `karukan-im/core/src/core/engine/types.rs`
+- Test: `karukan-im/core/src/core/engine/tests/basic.rs`
 
 **Interfaces:**
 - Consumes: Task 1 の `Settings.keys.ctrl_space_fullwidth`。
@@ -148,7 +148,7 @@ git ai-commit
 
 - [ ] **Step 1: 失敗するテストを書く**
 
-`karukan-im/src/core/engine/tests/basic.rs` の末尾に追記：
+`karukan-im/core/src/core/engine/tests/basic.rs` の末尾に追記：
 
 ```rust
 #[test]
@@ -173,7 +173,7 @@ Expected: コンパイルエラー（`EngineConfig` に `ctrl_space_fullwidth` �
 
 - [ ] **Step 3: 最小実装**
 
-`karukan-im/src/core/engine/types.rs` の `EngineConfig` 構造体（`pub live_conversion: bool,` の後）にフィールドを追加：
+`karukan-im/core/src/core/engine/types.rs` の `EngineConfig` 構造体（`pub live_conversion: bool,` の後）にフィールドを追加：
 
 ```rust
     /// Whether Ctrl+Space inputs a full-width space (U+3000).
@@ -206,7 +206,7 @@ Expected: エラーなし（`with_config` を使う既存テストの構造体�
 - [ ] **Step 6: コミット**
 
 ```bash
-git add karukan-im/src/core/engine/types.rs karukan-im/src/core/engine/tests/basic.rs
+git add karukan-im/core/src/core/engine/types.rs karukan-im/core/src/core/engine/tests/basic.rs
 git ai-commit
 ```
 
@@ -215,8 +215,8 @@ git ai-commit
 ### Task 3: Empty 状態の Ctrl+Space をフラグで分岐する
 
 **Files:**
-- Modify: `karukan-im/src/core/engine/input.rs`（`process_key_empty`）
-- Test: `karukan-im/src/core/engine/tests/basic.rs`
+- Modify: `karukan-im/core/src/core/engine/input.rs`（`process_key_empty`）
+- Test: `karukan-im/core/src/core/engine/tests/basic.rs`
 
 **Interfaces:**
 - Consumes: Task 2 の `self.config.ctrl_space_fullwidth`。
@@ -224,7 +224,7 @@ git ai-commit
 
 - [ ] **Step 1: 失敗するテストを書く**
 
-`karukan-im/src/core/engine/tests/basic.rs` の末尾に追記。`press_ctrl` は `tests/mod.rs` で定義済み（`use super::*` で利用可能）：
+`karukan-im/core/src/core/engine/tests/basic.rs` の末尾に追記。`press_ctrl` は `tests/mod.rs` で定義済み（`use super::*` で利用可能）：
 
 ```rust
 #[test]
@@ -262,7 +262,7 @@ Expected: `ctrl_space_passes_through_in_empty_when_disabled` が FAIL（現状�
 
 - [ ] **Step 3: 最小実装**
 
-`karukan-im/src/core/engine/input.rs` の `process_key_empty` 冒頭の Ctrl+Space ブロックを次に置き換える：
+`karukan-im/core/src/core/engine/input.rs` の `process_key_empty` 冒頭の Ctrl+Space ブロックを次に置き換える：
 
 ```rust
         // Ctrl+Space: start input with full-width space.
@@ -291,7 +291,7 @@ Expected: Task 2・Task 3 の Ctrl+Space 関連テストが全て PASS。
 - [ ] **Step 5: コミット**
 
 ```bash
-git add karukan-im/src/core/engine/input.rs karukan-im/src/core/engine/tests/basic.rs
+git add karukan-im/core/src/core/engine/input.rs karukan-im/core/src/core/engine/tests/basic.rs
 git ai-commit
 ```
 
@@ -300,8 +300,8 @@ git ai-commit
 ### Task 4: Composing 状態の Ctrl+Space をフラグで分岐する
 
 **Files:**
-- Modify: `karukan-im/src/core/engine/input.rs`（`process_key_composing`）
-- Test: `karukan-im/src/core/engine/tests/basic.rs`
+- Modify: `karukan-im/core/src/core/engine/input.rs`（`process_key_composing`）
+- Test: `karukan-im/core/src/core/engine/tests/basic.rs`
 
 **Interfaces:**
 - Consumes: Task 2 の `self.config.ctrl_space_fullwidth`。
@@ -311,7 +311,7 @@ git ai-commit
 
 - [ ] **Step 1: 失敗するテストを書く**
 
-`karukan-im/src/core/engine/tests/basic.rs` の末尾に追記：
+`karukan-im/core/src/core/engine/tests/basic.rs` の末尾に追記：
 
 ```rust
 #[test]
@@ -353,7 +353,7 @@ Expected: `ctrl_space_passes_through_while_composing_when_disabled` が FAIL（�
 
 - [ ] **Step 3: 最小実装**
 
-`karukan-im/src/core/engine/input.rs` の `process_key_composing` の Ctrl 分岐内、`Keysym::SPACE` のアームを次に置き換える：
+`karukan-im/core/src/core/engine/input.rs` の `process_key_composing` の Ctrl 分岐内、`Keysym::SPACE` のアームを次に置き換える：
 
 ```rust
                 // Ctrl+Space: insert full-width space (U+3000), unless
@@ -389,7 +389,7 @@ Expected: 差分なし（差分があれば `cargo fmt --all` を実行してか
 - [ ] **Step 6: コミット**
 
 ```bash
-git add karukan-im/src/core/engine/input.rs karukan-im/src/core/engine/tests/basic.rs
+git add karukan-im/core/src/core/engine/input.rs karukan-im/core/src/core/engine/tests/basic.rs
 git ai-commit
 ```
 

--- a/docs/superpowers/specs/2026-07-01-configurable-ctrl-space-design.md
+++ b/docs/superpowers/specs/2026-07-01-configurable-ctrl-space-design.md
@@ -76,6 +76,8 @@ ctrl_space_fullwidth = true
 
 Composing (変換中) に Ctrl+Space を押すと、未確定の preedit (下線テキスト) が残ったまま OS のショートカット (ウインドウ切替等) が発火する。「未入力時・入力中の両方で OS へ渡す」という決定に基づく想定内の挙動として受容する。
 
+また、本機能のスコープは Empty / Composing の 2 状態に限る。候補ウィンドウを開いている Conversion 状態では、Ctrl+Space は `ctrl_space_fullwidth` の値によらず従来通り「次の候補へ」として消費され、OS へは渡らない (`process_key_conversion` は Space を候補送りに割り当てているため)。候補ウィンドウ表示中にウインドウ切替を行う場面は稀であり、既存の bare-Space の候補送り挙動と揃える意図で、この状態は今回の設定対象外とする。
+
 ## テスト
 
 `karukan-im` のエンジンテストに以下 4 ケースを追加する。

--- a/docs/superpowers/specs/2026-07-01-configurable-ctrl-space-design.md
+++ b/docs/superpowers/specs/2026-07-01-configurable-ctrl-space-design.md
@@ -1,0 +1,102 @@
+# Ctrl+Space の全角スペース挙動を config.toml で切替可能にする
+
+## 背景と問題
+
+Karukan は Ctrl+Space を「全角スペース入力」として意図的に横取りしている。
+
+- 未入力時 (Empty): `karukan-im/src/core/engine/input.rs` の `process_key_empty` で、Ctrl+Space を全角スペース (U+3000) の Composing セッション開始として消費する。
+- 入力中 (Composing): 同ファイル `process_key_composing` で、Ctrl+Space を全角スペース挿入 (`input_fullwidth_space`) として消費する。
+
+いずれも `EngineResult::consumed()` を返すため、フロントエンド (macOS Swift / Linux fcitx5 C++) はキーイベントを飲み込み、OS へ伝播しない。その結果、ユーザーが OS 側に割り当てた Ctrl+Space ショートカット (例: macOS の「次のウインドウを操作対象にする」) が発火せず、代わりに全角スペースが入力される。
+
+現状 Karukan には GUI 設定画面が存在せず、設定は `config.toml` の手編集で行う (Linux fcitx5 のアドオンは `Configurable=True` と宣言しているが C++ 側に設定 API 実装がなく実質機能しない)。この挙動もハードコードされており変更できない。
+
+## ゴール
+
+`config.toml` の設定で、Ctrl+Space を全角スペース入力に使うか、OS へ素通しするかを切り替えられるようにする。
+
+- 無効化 (`false`) 時は、未入力時・入力中の**両方**で Ctrl+Space を横取りせず OS へ渡す。
+- デフォルトは `true` (既存挙動を維持し、後方互換を保つ)。
+- Rust エンジン (`karukan-im`) のみの変更で macOS / Linux 両対応とする。
+
+## 非ゴール
+
+- 汎用キーバインド設定 (任意の機能に任意のキーを割り当てる仕組み) は作らない。今回は Ctrl+Space の ON/OFF ブール 1 個に絞る。
+- GUI 設定画面は作らない。設定は `config.toml` 手編集のまま。
+- フロントエンド (Swift / C++) のコードは変更しない。
+
+## 設計
+
+### 1. 設定項目
+
+`config/default.toml` に新セクション `[keys]` を追加する。
+
+```toml
+[keys]
+# Ctrl+Space を全角スペース入力に使う。
+# false にすると Karukan は Ctrl+Space を横取りせず OS に渡す
+# （macOS/Linux のウインドウ切替などのショートカットが効くようになる）。
+ctrl_space_fullwidth = true
+```
+
+`[conversion]` ではなく新セクション `[keys]` にする理由: これは変換設定ではなくキー割り当ての挙動であり、意味的に分離する。今後キー系設定が増えた際の置き場所にもなる。
+
+### 2. 設定の型定義と伝搬経路
+
+既存の設定と全く同じ経路を辿る。
+
+1. `karukan-im/src/config/settings.rs`
+   - 新しい構造体 `KeysSettings { ctrl_space_fullwidth: bool }` を追加。
+   - `Settings` に `pub keys: KeysSettings` フィールドを追加。
+   - `merge_toml` + `parse_with_defaults` により、ユーザーが `[keys]` を書かなくても埋め込み `default.toml` の値で埋まる (既存の仕組みをそのまま利用)。
+2. `karukan-im/src/core/engine/types.rs`
+   - `EngineConfig` に `pub ctrl_space_fullwidth: bool` を追加。
+   - `EngineConfig::from_settings` (`types.rs:96`) で `settings.keys.ctrl_space_fullwidth` を反映。
+   - `impl Default for EngineConfig` (`types.rs:115`) で `true` を設定 (既存挙動維持)。
+
+### 3. キー処理の分岐 (`karukan-im/src/core/engine/input.rs`)
+
+- **Empty 状態** (`process_key_empty`, 現 `input.rs:122-131`)
+  - `self.config.ctrl_space_fullwidth == false` かつ Ctrl+Space の場合、全角スペース分岐に入らず `EngineResult::not_consumed()` を返す。
+  - (この分岐をスキップするだけでも、後続の bare-space 分岐は `!key.modifiers.control_key` 条件で該当しないため最終的に `not_consumed` に落ちるが、意図を明示するため明示的に early-return する。)
+- **Composing 状態** (`process_key_composing`, 現 `input.rs:257-273` の Ctrl 分岐)
+  - `self.config.ctrl_space_fullwidth == false` かつ Ctrl+Space の場合、**明示的に `EngineResult::not_consumed()` を返す**。
+  - 注意: 単に全角スペース分岐をスキップすると、下の `match` で `Keysym::SPACE | Keysym::DOWN => self.start_conversion(false)` に該当し、Ctrl+Space が変換トリガーとして誤消費される。これを防ぐため明示的な early-return が必須。
+
+### 4. フロントエンド
+
+エンジンが `not_consumed` を返すと、既存のフロントは OS へキーを素通しする。
+
+- macOS: `KarukanInputController.handle()` が `result.consumed == false` で `return false` する (`KarukanInputController.swift:70`)。
+- Linux fcitx5: keyEvent が consumed でなければ `filterAndTransformKey` せず OS へ渡る。
+
+いずれもコード変更は不要。
+
+## 副作用と受容する挙動
+
+Composing (変換中) に Ctrl+Space を押すと、未確定の preedit (下線テキスト) が残ったまま OS のショートカット (ウインドウ切替等) が発火する。「未入力時・入力中の両方で OS へ渡す」という決定に基づく想定内の挙動として受容する。
+
+## テスト
+
+`karukan-im` のエンジンテストに以下 4 ケースを追加する。
+
+| flag | 状態 | 入力 | 期待 |
+|---|---|---|---|
+| `true` (default) | Empty | Ctrl+Space | 全角スペース (U+3000) で Composing 開始 (既存挙動) |
+| `false` | Empty | Ctrl+Space | `not_consumed` (OS へ素通し) |
+| `true` (default) | Composing | Ctrl+Space | 全角スペース挿入 (既存挙動) |
+| `false` | Composing | Ctrl+Space | `not_consumed` (変換トリガーにならない) |
+
+加えて、`settings.rs` に `[keys]` セクションの読み込み・デフォルト値のテストを追加する (既存の `test_partial_config` / `test_default_settings` に倣う)。
+
+## 影響範囲まとめ
+
+変更ファイル:
+
+- `karukan-im/config/default.toml` — `[keys]` セクション追加
+- `karukan-im/src/config/settings.rs` — `KeysSettings` 追加、`Settings` にフィールド追加、テスト追加
+- `karukan-im/src/core/engine/types.rs` — `EngineConfig` にフィールド追加、`from_settings` / `Default` 反映
+- `karukan-im/src/core/engine/input.rs` — Empty / Composing の Ctrl+Space 分岐に flag チェック追加
+- `karukan-im/src/core/engine/tests/` (または `tests.rs`) — 4 ケース追加
+
+変更しないもの: macOS Swift、Linux fcitx5 C++、その他フロントエンド。

--- a/docs/superpowers/specs/2026-07-01-configurable-ctrl-space-design.md
+++ b/docs/superpowers/specs/2026-07-01-configurable-ctrl-space-design.md
@@ -4,7 +4,7 @@
 
 Karukan は Ctrl+Space を「全角スペース入力」として意図的に横取りしている。
 
-- 未入力時 (Empty): `karukan-im/src/core/engine/input.rs` の `process_key_empty` で、Ctrl+Space を全角スペース (U+3000) の Composing セッション開始として消費する。
+- 未入力時 (Empty): `karukan-im/core/src/core/engine/input.rs` の `process_key_empty` で、Ctrl+Space を全角スペース (U+3000) の Composing セッション開始として消費する。
 - 入力中 (Composing): 同ファイル `process_key_composing` で、Ctrl+Space を全角スペース挿入 (`input_fullwidth_space`) として消費する。
 
 いずれも `EngineResult::consumed()` を返すため、フロントエンド (macOS Swift / Linux fcitx5 C++) はキーイベントを飲み込み、OS へ伝播しない。その結果、ユーザーが OS 側に割り当てた Ctrl+Space ショートカット (例: macOS の「次のウインドウを操作対象にする」) が発火せず、代わりに全角スペースが入力される。
@@ -29,7 +29,7 @@ Karukan は Ctrl+Space を「全角スペース入力」として意図的に横
 
 ### 1. 設定項目
 
-`config/default.toml` に新セクション `[keys]` を追加する。
+`karukan-im/core/config/default.toml` に新セクション `[keys]` を追加する。
 
 ```toml
 [keys]
@@ -45,16 +45,16 @@ ctrl_space_fullwidth = true
 
 既存の設定と全く同じ経路を辿る。
 
-1. `karukan-im/src/config/settings.rs`
+1. `karukan-im/core/src/config/settings.rs`
    - 新しい構造体 `KeysSettings { ctrl_space_fullwidth: bool }` を追加。
    - `Settings` に `pub keys: KeysSettings` フィールドを追加。
    - `merge_toml` + `parse_with_defaults` により、ユーザーが `[keys]` を書かなくても埋め込み `default.toml` の値で埋まる (既存の仕組みをそのまま利用)。
-2. `karukan-im/src/core/engine/types.rs`
+2. `karukan-im/core/src/core/engine/types.rs`
    - `EngineConfig` に `pub ctrl_space_fullwidth: bool` を追加。
    - `EngineConfig::from_settings` (`types.rs:96`) で `settings.keys.ctrl_space_fullwidth` を反映。
    - `impl Default for EngineConfig` (`types.rs:115`) で `true` を設定 (既存挙動維持)。
 
-### 3. キー処理の分岐 (`karukan-im/src/core/engine/input.rs`)
+### 3. キー処理の分岐 (`karukan-im/core/src/core/engine/input.rs`)
 
 - **Empty 状態** (`process_key_empty`, 現 `input.rs:122-131`)
   - `self.config.ctrl_space_fullwidth == false` かつ Ctrl+Space の場合、全角スペース分岐に入らず `EngineResult::not_consumed()` を返す。
@@ -95,10 +95,10 @@ Composing (変換中) に Ctrl+Space を押すと、未確定の preedit (下線
 
 変更ファイル:
 
-- `karukan-im/config/default.toml` — `[keys]` セクション追加
-- `karukan-im/src/config/settings.rs` — `KeysSettings` 追加、`Settings` にフィールド追加、テスト追加
-- `karukan-im/src/core/engine/types.rs` — `EngineConfig` にフィールド追加、`from_settings` / `Default` 反映
-- `karukan-im/src/core/engine/input.rs` — Empty / Composing の Ctrl+Space 分岐に flag チェック追加
-- `karukan-im/src/core/engine/tests/` (または `tests.rs`) — 4 ケース追加
+- `karukan-im/core/config/default.toml` — `[keys]` セクション追加
+- `karukan-im/core/src/config/settings.rs` — `KeysSettings` 追加、`Settings` にフィールド追加、テスト追加
+- `karukan-im/core/src/core/engine/types.rs` — `EngineConfig` にフィールド追加、`from_settings` / `Default` 反映
+- `karukan-im/core/src/core/engine/input.rs` — Empty / Composing の Ctrl+Space 分岐に flag チェック追加
+- `karukan-im/core/src/core/engine/tests/` (または `tests.rs`) — 4 ケース追加
 
 変更しないもの: macOS Swift、Linux fcitx5 C++、その他フロントエンド。

--- a/karukan-im/core/config/default.toml
+++ b/karukan-im/core/config/default.toml
@@ -38,3 +38,9 @@ enabled = true
 max_entries = 10000
 # 学習する変換結果の最大文字数
 max_surface_chars = 50
+
+[keys]
+# Ctrl+Space を全角スペース入力に使う。
+# false にすると Karukan は Ctrl+Space を横取りせず OS に渡す
+# （macOS/Linux のウインドウ切替などのショートカットが効くようになる）。
+ctrl_space_fullwidth = true

--- a/karukan-im/core/src/config/settings.rs
+++ b/karukan-im/core/src/config/settings.rs
@@ -21,6 +21,8 @@ pub struct Settings {
     pub conversion: ConversionSettings,
     /// Learning cache settings
     pub learning: LearningSettings,
+    /// Key-binding behavior settings
+    pub keys: KeysSettings,
 }
 
 /// Conversion strategy mode
@@ -83,6 +85,15 @@ pub struct LearningSettings {
     /// cache; longer conversion results (e.g. whole live-converted
     /// sentences) are not learned
     pub max_surface_chars: usize,
+}
+
+/// Key-binding behavior settings
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct KeysSettings {
+    /// Use Ctrl+Space to input a full-width space (U+3000).
+    /// When false, Karukan does not intercept Ctrl+Space and lets it pass
+    /// through to the OS (so window-switching shortcuts etc. still work).
+    pub ctrl_space_fullwidth: bool,
 }
 
 impl Default for Settings {
@@ -344,5 +355,30 @@ strategy = "main"
         let path = file.path().to_path_buf();
         let settings = Settings::load_from(&path).unwrap();
         assert_eq!(settings.conversion.strategy, StrategyMode::Main);
+    }
+
+    #[test]
+    fn test_keys_default_ctrl_space_fullwidth() {
+        let settings = Settings::default();
+        assert!(settings.keys.ctrl_space_fullwidth);
+    }
+
+    #[test]
+    fn test_keys_override_and_other_sections_keep_defaults() {
+        let mut file = NamedTempFile::new().unwrap();
+        writeln!(
+            file,
+            r#"
+[keys]
+ctrl_space_fullwidth = false
+"#
+        )
+        .unwrap();
+
+        let path = file.path().to_path_buf();
+        let settings = Settings::load_from(&path).unwrap();
+        assert!(!settings.keys.ctrl_space_fullwidth);
+        // Sections the user did not specify still fall back to defaults.
+        assert_eq!(settings.conversion.num_candidates, 9);
     }
 }

--- a/karukan-im/core/src/core/engine/input.rs
+++ b/karukan-im/core/src/core/engine/input.rs
@@ -238,8 +238,18 @@ impl InputMethodEngine {
         // Handle Ctrl+key shortcuts
         if key.modifiers.control_key {
             match key.keysym {
-                // Ctrl+Space: insert full-width space (U+3000)
-                Keysym::SPACE => return self.input_fullwidth_space(),
+                // Ctrl+Space: insert full-width space (U+3000), unless
+                // disabled in config — then pass through to the OS. Must
+                // return explicitly here: falling through would let the
+                // bare-Space arm below treat Ctrl+Space as the conversion
+                // trigger.
+                Keysym::SPACE => {
+                    return if self.config.ctrl_space_fullwidth {
+                        self.input_fullwidth_space()
+                    } else {
+                        EngineResult::not_consumed()
+                    };
+                }
                 // Ctrl+K: enter katakana mode
                 Keysym::KEY_K | Keysym::KEY_K_UPPER => return self.enter_katakana_mode(),
                 // Ctrl+A: move to beginning (Emacs-style Home)

--- a/karukan-im/core/src/core/engine/input.rs
+++ b/karukan-im/core/src/core/engine/input.rs
@@ -121,7 +121,6 @@ impl InputMethodEngine {
             if !self.config.ctrl_space_fullwidth {
                 return EngineResult::not_consumed();
             }
-            self.converters.romaji.reset();
             self.input_buf.clear();
             self.input_buf.push_direct('\u{3000}');
             let preedit = self.set_composing_state();

--- a/karukan-im/core/src/core/engine/input.rs
+++ b/karukan-im/core/src/core/engine/input.rs
@@ -113,8 +113,15 @@ impl InputMethodEngine {
 
     /// Process key in empty state
     pub(super) fn process_key_empty(&mut self, key: &KeyEvent, shift_active: bool) -> EngineResult {
-        // Ctrl+Space: start input with full-width space
+        // Ctrl+Space: start input with full-width space.
+        // Gated on config: when `ctrl_space_fullwidth` is false, do not
+        // intercept — return not_consumed so the key passes through to the
+        // OS (e.g. window-switching shortcuts).
         if key.modifiers.control_key && key.keysym == Keysym::SPACE {
+            if !self.config.ctrl_space_fullwidth {
+                return EngineResult::not_consumed();
+            }
+            self.converters.romaji.reset();
             self.input_buf.clear();
             self.input_buf.push_direct('\u{3000}');
             let preedit = self.set_composing_state();

--- a/karukan-im/core/src/core/engine/tests/basic.rs
+++ b/karukan-im/core/src/core/engine/tests/basic.rs
@@ -179,3 +179,17 @@ fn test_truncate_context() {
     let jp = engine.truncate_context("今日はとても良い天気");
     assert_eq!(jp.chars().count(), 5); // Last 5 chars
 }
+
+#[test]
+fn ctrl_space_fullwidth_defaults_true_in_engine_config() {
+    let config = EngineConfig::default();
+    assert!(config.ctrl_space_fullwidth);
+}
+
+#[test]
+fn ctrl_space_fullwidth_maps_from_settings() {
+    let mut settings = crate::config::Settings::default();
+    assert!(EngineConfig::from_settings(&settings).ctrl_space_fullwidth);
+    settings.keys.ctrl_space_fullwidth = false;
+    assert!(!EngineConfig::from_settings(&settings).ctrl_space_fullwidth);
+}

--- a/karukan-im/core/src/core/engine/tests/basic.rs
+++ b/karukan-im/core/src/core/engine/tests/basic.rs
@@ -220,3 +220,34 @@ fn ctrl_space_passes_through_in_empty_when_disabled() {
         result.actions
     );
 }
+
+#[test]
+fn ctrl_space_inserts_fullwidth_space_while_composing_when_enabled() {
+    let mut engine = InputMethodEngine::new();
+    engine.process_key(&press('a')); // preedit "あ", Composing
+    let result = engine.process_key(&press_ctrl(Keysym::SPACE));
+    assert!(result.consumed);
+    assert!(matches!(engine.state(), InputState::Composing { .. }));
+    assert!(
+        engine.input_buf.text.contains('\u{3000}'),
+        "buffer should contain a full-width space, got {:?}",
+        engine.input_buf.text
+    );
+}
+
+#[test]
+fn ctrl_space_passes_through_while_composing_when_disabled() {
+    let config = EngineConfig {
+        ctrl_space_fullwidth: false,
+        ..EngineConfig::default()
+    };
+    let mut engine = InputMethodEngine::with_config(config);
+    engine.process_key(&press('a')); // preedit "あ", Composing
+    let result = engine.process_key(&press_ctrl(Keysym::SPACE));
+    assert!(!result.consumed);
+    // Must NOT trigger conversion (the fall-through bug guard) and must
+    // NOT insert a full-width space.
+    assert!(matches!(engine.state(), InputState::Composing { .. }));
+    assert_eq!(engine.preedit().unwrap().text(), "あ");
+    assert!(!engine.input_buf.text.contains('\u{3000}'));
+}

--- a/karukan-im/core/src/core/engine/tests/basic.rs
+++ b/karukan-im/core/src/core/engine/tests/basic.rs
@@ -193,3 +193,30 @@ fn ctrl_space_fullwidth_maps_from_settings() {
     settings.keys.ctrl_space_fullwidth = false;
     assert!(!EngineConfig::from_settings(&settings).ctrl_space_fullwidth);
 }
+
+#[test]
+fn ctrl_space_inputs_fullwidth_space_in_empty_when_enabled() {
+    // Default config has ctrl_space_fullwidth = true.
+    let mut engine = InputMethodEngine::new();
+    let result = engine.process_key(&press_ctrl(Keysym::SPACE));
+    assert!(result.consumed);
+    assert!(matches!(engine.state(), InputState::Composing { .. }));
+    assert_eq!(engine.preedit().unwrap().text(), "\u{3000}");
+}
+
+#[test]
+fn ctrl_space_passes_through_in_empty_when_disabled() {
+    let config = EngineConfig {
+        ctrl_space_fullwidth: false,
+        ..EngineConfig::default()
+    };
+    let mut engine = InputMethodEngine::with_config(config);
+    let result = engine.process_key(&press_ctrl(Keysym::SPACE));
+    assert!(!result.consumed);
+    assert!(matches!(engine.state(), InputState::Empty));
+    assert!(
+        result.actions.is_empty(),
+        "expected no actions, got {:?}",
+        result.actions
+    );
+}

--- a/karukan-im/core/src/core/engine/tests/basic.rs
+++ b/karukan-im/core/src/core/engine/tests/basic.rs
@@ -229,9 +229,9 @@ fn ctrl_space_inserts_fullwidth_space_while_composing_when_enabled() {
     assert!(result.consumed);
     assert!(matches!(engine.state(), InputState::Composing { .. }));
     assert!(
-        engine.input_buf.text.contains('\u{3000}'),
+        engine.input_buf.reading().contains('\u{3000}'),
         "buffer should contain a full-width space, got {:?}",
-        engine.input_buf.text
+        engine.input_buf.reading()
     );
 }
 
@@ -249,5 +249,5 @@ fn ctrl_space_passes_through_while_composing_when_disabled() {
     // NOT insert a full-width space.
     assert!(matches!(engine.state(), InputState::Composing { .. }));
     assert_eq!(engine.preedit().unwrap().text(), "あ");
-    assert!(!engine.input_buf.text.contains('\u{3000}'));
+    assert!(!engine.input_buf.reading().contains('\u{3000}'));
 }

--- a/karukan-im/core/src/core/engine/types.rs
+++ b/karukan-im/core/src/core/engine/types.rs
@@ -88,6 +88,9 @@ pub struct EngineConfig {
     pub strategy: StrategyMode,
     /// Whether live conversion is enabled at engine startup
     pub live_conversion: bool,
+    /// Whether Ctrl+Space inputs a full-width space (U+3000).
+    /// When false, Ctrl+Space is not consumed and passes through to the OS.
+    pub ctrl_space_fullwidth: bool,
 }
 
 impl EngineConfig {
@@ -108,6 +111,7 @@ impl EngineConfig {
             max_latency_ms: settings.conversion.max_latency_ms,
             strategy: settings.conversion.strategy,
             live_conversion: settings.conversion.live_conversion,
+            ctrl_space_fullwidth: settings.keys.ctrl_space_fullwidth,
         }
     }
 }
@@ -124,6 +128,7 @@ impl Default for EngineConfig {
             max_latency_ms: 100,
             strategy: StrategyMode::default(),
             live_conversion: false,
+            ctrl_space_fullwidth: true,
         }
     }
 }


### PR DESCRIPTION
## 概要

Ctrl+Space を全角スペース (U+3000) 入力に使うかどうかを `config.toml` で切り替えられるようにします。

これまで Ctrl+Space は Karukan が消費して全角スペースを入力していました。そのため、ユーザーが OS 側に割り当てた Ctrl+Space ショートカットが発火せず、代わりに全角スペースが入ってしまっていました。本 PR で `keys.ctrl_space_fullwidth = false` を設定すると、Karukan は Ctrl+Space を消費せず OS へ素通しするようになります。

## 背景

- 設定は `config.toml` の手編集で行います。この Ctrl+Space の挙動もハードコードされており、変更できませんでした。
- Ctrl+Space は 2 箇所で全角スペースになっていました。未入力時 (Empty, `process_key_empty`) と入力中 (Composing, `process_key_composing`) です。いずれも `consumed` を返すため、フロントがキーを飲み込み OS に届きませんでした。

## 変更内容

- `karukan-im/config/default.toml`: 新セクション `[keys]` と `ctrl_space_fullwidth`（デフォルト `true`）を追加します。
- `karukan-im/src/config/settings.rs`: `KeysSettings` 構造体と `Settings.keys` フィールドを追加します。ユーザー設定に `[keys]` が無い場合も、既存の `merge_toml` でデフォルトが埋まります。
- `karukan-im/src/core/engine/types.rs`: `EngineConfig` に `ctrl_space_fullwidth: bool` を追加し、`from_settings`（設定から反映）と `Default`（`true`）に反映します。
- `karukan-im/src/core/engine/input.rs`: Empty / Composing 両状態の Ctrl+Space 分岐に flag チェックを追加します。`false` のときは `not_consumed` を返して OS へ素通しします。Composing 側は変換トリガーへのフォールスルーを防ぐため、明示的に `not_consumed` を返します。

`not_consumed` を返せばフロント（macOS Swift / Linux fcitx5）が自動で OS へキーを渡すため、**フロントエンド (Swift / C++) は無変更**で macOS / Linux 両対応となります。

## 挙動

| `ctrl_space_fullwidth` | Empty / Composing での Ctrl+Space |
| --- | --- |
| `true`（デフォルト・従来通り） | 全角スペース (U+3000) を入力します |
| `false` | OS へ素通しします（ウインドウ切替などのショートカットが効きます） |

デフォルトは `true` のため、既存ユーザーの挙動は変わりません（後方互換です）。

## スコープ外（意図的）

候補ウィンドウ表示中（Conversion 状態）の Ctrl+Space は、`ctrl_space_fullwidth` の値によらず従来通り「次の候補へ」として消費されます。候補表示中のウインドウ切替は稀であり、既存の bare-Space の候補送り挙動と揃える意図で、今回の設定対象外としています（設計 spec に明記しています）。

## テスト

- `karukan-im` の全テスト 227 件が pass し、`cargo clippy` / `cargo fmt --check` もクリーンです。
- 追加したテストは次のとおりです。
  - 設定読み込み: `[keys]` のデフォルト値、`false` オーバーライド、未指定セクションのデフォルト維持
  - 設定伝搬: `EngineConfig` のデフォルト `true`、`from_settings` マッピング
  - キー挙動: Empty × 2（有効/無効）、Composing × 2（有効/無効。無効側は変換トリガーへ誤消費しないことを検証）

