### PR TITLE
Proposal: Shift+Space で半角スペースを入力できるようにする

### DIFF
--- a/karukan-im/README.md
+++ b/karukan-im/README.md
@@ -9,3 +9,176 @@ Karukan の IME 本体。共有エンジンと各プラットフォームのフ�
 | [macos/](macos/) | macOS向けフロントエンド — Swift/InputMethodKit |
 
 キーバインド・設定・辞書などユーザー向けドキュメントは [docs/](../docs/) を、インストール手順は各フロントエンドの README を参照してください。
+
+## Features
+
+- ニューラルかな漢字変換（llama.cppによるGGUF推論）
+- 変換学習（ユーザーの変換履歴を記憶し、完全一致・前方一致で候補を優先表示）
+- 日本語・英数字の混合入力（Shift切り替え）
+- Surrounding Textによる文脈を考慮した変換
+- システム辞書・ユーザー辞書による候補補完
+
+> [!NOTE]
+> モデル推論だけでは語彙が限られるため、システム辞書の併用を強く推奨します。システム辞書はIMEに同梱されていないため、別途インストールが必要です。詳しくは [Dictionary](#dictionary) を参照してください。
+
+## Key Bindings
+
+### ひらがな入力モード
+
+| キー | 動作 |
+|------|------|
+| 文字キー | ローマ字入力 → ひらがな変換 |
+| Space / Tab / ↓ | かな漢字変換を開始 |
+| Enter | ひらがなのまま確定 |
+| Escape | 入力をキャンセル |
+| Backspace | 1文字削除 |
+| Delete | カーソル位置の文字を削除 |
+| ← → | カーソル移動 |
+| Home / End | カーソルを先頭 / 末尾に移動 |
+| Ctrl+K | カタカナモードに切り替え |
+| Ctrl+Space | 全角スペースを入力 |
+| Shift+Space | 半角スペースを入力（`shift_space_halfwidth = true` のとき有効。入力中は確定してから半角スペース。既定は無効） |
+
+### 変換モード
+
+| キー | 動作 |
+|------|------|
+| Space / Tab / ↓ | 次の候補 |
+| ↑ | 前の候補 |
+| 1-9 | 候補を番号で選択・確定 |
+| Enter | 選択中の候補を確定 |
+| Escape | 変換をキャンセル（ひらがなに戻る） |
+| 文字キー | 選択中の候補を確定して新しい入力を開始 |
+
+### モード切り替え
+
+| キー | 動作 |
+|------|------|
+| Shift+英字 | 英数字モードに切り替え + 大文字入力 |
+| Ctrl+K | カタカナモードに切り替え |
+| Right Super | 英数字/カタカナ → ひらがなモードに復帰 |
+| Ctrl+Shift+L | ライブ変換のON/OFF |
+
+### 英数字モード
+
+英数字モードでは文字がローマ字変換されず、そのまま入力されます。日本語と英語を混ぜて入力し、Spaceで変換するとひらがな部分のみ変換されます。
+
+例: `わたしはLinuxが` → 変換 → `私はLinuxが`
+
+## Configuration
+
+設定ファイル: `~/.config/karukan-im/config.toml`（macOS: `~/Library/Application Support/com.karukan.karukan-im/config.toml`）
+
+```toml
+[conversion]
+live_conversion = true          # ライブ変換を起動時に有効化（Ctrl+Shift+L で実行中も切替。既定ON）
+composing_chunk_len = 30        # ライブ変換で1回のモデル変換が扱う読みの最大文字数（= 1キーあたりレイテンシの上限）
+strategy = "adaptive"           # 変換ストラテジー（adaptive / light / main）
+num_candidates = 9              # 変換候補数（Space押下時）
+n_threads = 4                   # 推論スレッド数（0 = 全コア使用）
+model = "jinen-v2-small-q5"     # メインモデル（モデルID or GGUFパス）
+light_model = "jinen-v1-xsmall-q5"  # 軽量モデル（ビームサーチ・長文用）
+use_context = true              # Surrounding Textを変換に使用する
+max_context_length = 10         # コンテキストの最大文字数
+short_input_threshold = 10      # ビームサーチを使うトークン数の上限
+beam_width = 3                  # ビーム幅
+max_latency_ms = 100            # メインモデルの許容レイテンシ（ms）。超過時は軽量モデルに自動切替（0 = 無効）
+dict_path = "/path/to/dict.bin" # システム辞書パス（省略時はデータディレクトリの dict.bin。[Dictionary](#dictionary) 参照）
+
+[learning]
+enabled = true                 # 変換学習の有効/無効
+max_entries = 10000            # 学習エントリの最大数
+
+[keys]
+shift_space_halfwidth = false  # Shift+Space で半角スペースを入力（既定OFF）
+```
+
+> [!NOTE]
+> 上記は主要な設定項目の抜粋です。全項目の正確な既定値と説明は [`core/config/default.toml`](core/config/default.toml) を参照してください（各設定行に日本語コメント付き）。
+
+### Live Conversion
+
+入力と同時にかな漢字変換の結果をプリエディットへリアルタイム表示します（Spaceを押さずに変換が進む）。`Ctrl+Shift+L` でON/OFFを切り替えられ、既定では `live_conversion = true` で有効です。
+
+長文入力でも1キーあたりのレイテンシを一定に保つため、変換中のバッファを内部で最大 `composing_chunk_len` 文字（既定30）のチャンクに分割し、編集した箇所のチャンクだけを再変換します。チャンクは内部的な分割で、ユーザーには連続した1つのプリエディットとして見えます。記号・数字の連続は日本語とは別チャンクに分けてそのまま通すため、`123456` のような並びが変換で崩れることはありません。
+
+### Conversion Strategy
+
+`strategy` で変換時のモデル使い分けを制御できます。
+
+| 値 | 説明 | 読み込むモデル |
+|---|---|---|
+| `adaptive` | デフォルト。レイテンシに応じてメイン・軽量モデルを動的に切り替え | メイン + 軽量 |
+| `light` | 軽量モデルのみ使用。メモリ消費が少なく、低スペックPCにおすすめ | 軽量のみ |
+| `main` | メインモデルのみ使用（ビームサーチなし） | メインのみ |
+
+低スペックのPC（メモリが少ない、CPUが遅い等）では `strategy = "light"` を設定すると、軽量モデル1つだけで動作するためメモリ使用量が削減され、レスポンスも安定します。
+
+```toml
+[conversion]
+strategy = "light"
+```
+
+### Performance Tuning
+
+CPU高負荷時（Rustビルド中など）にかな漢字変換が遅くなる場合は、`n_threads` を小さくするとレスポンスが改善します。
+
+### Dictionary
+
+辞書の構築・管理については [karukan-cli の README](../karukan-cli/README.md) を参照してください。
+
+#### System Dictionary
+
+double-array trieベースのシステム辞書で、モデル推論に加えて辞書からの変換候補を提供します。
+
+- デフォルトパス: `~/.local/share/karukan-im/dict.bin`（macOS: `~/Library/Application Support/com.karukan.karukan-im/dict.bin`）
+- `dict_path` で任意のパスを指定可能
+- ファイルが存在しない場合は辞書なしで動作
+
+ビルド済みの辞書を以下からダウンロードして配置できます:
+
+```bash
+# Linux
+wget https://github.com/togatoga/karukan/releases/download/v0.1.0/dict.tgz
+tar xzf dict.tgz
+mkdir -p ~/.local/share/karukan-im
+cp dict.bin ~/.local/share/karukan-im/
+
+# macOS
+curl -LO https://github.com/togatoga/karukan/releases/download/v0.1.0/dict.tgz
+tar xzf dict.tgz
+mkdir -p ~/Library/"Application Support"/com.karukan.karukan-im
+cp dict.bin ~/Library/"Application Support"/com.karukan.karukan-im/
+```
+
+自分でビルドする場合は [karukan-cli の README](../karukan-cli/README.md) を参照してください。
+
+#### User Dictionary
+
+ユーザー辞書ディレクトリにファイルを配置すると、ユーザー辞書として読み込まれます。
+
+- デフォルトパス: `~/.local/share/karukan-im/user_dicts/`（macOS: `~/Library/Application Support/com.karukan.karukan-im/user_dicts/`）
+- ディレクトリ内のファイルはすべて自動で読み込み（KRKNバイナリ・Mozc TSV を自動判定）
+- ディレクトリが存在しない場合はユーザー辞書なしで動作
+
+変換候補の優先順位:
+
+1. 📝 学習キャッシュ
+2. 👤 ユーザー辞書
+3. 🤖 モデル推論
+4. 📚 システム辞書（スコア順）
+5. ひらがな / カタカナ
+6. 🔄 Rewriter（半角カタカナ・英字全角半角・記号バリアント）
+
+### Learning Cache
+
+ユーザーが選択した変換結果を記憶し、次回以降の変換で優先表示します。
+
+- 保存先: `~/.local/share/karukan-im/learning.tsv`（macOS: `~/Library/Application Support/com.karukan.karukan-im/learning.tsv`）
+- 完全一致と前方一致（予測変換）の両方に対応
+  - 例: 「早稲田大学」を一度変換すると、次回「わせだ」と入力した時点で候補に表示
+- 学習候補は変換時・入力中（auto-suggest）の両方で最大3件表示
+- スコアはrecency（最終使用日時）重視 + 頻度補正
+- IME切り替え・ウィンドウ切り替え時に自動保存（commit のたびには保存しない）
+- `[learning] enabled = false` で無効化可能
+- 学習履歴を削除するには: `rm ~/.local/share/karukan-im/learning.tsv`

--- a/karukan-im/core/config/default.toml
+++ b/karukan-im/core/config/default.toml
@@ -38,3 +38,10 @@ enabled = true
 max_entries = 10000
 # 学習する変換結果の最大文字数
 max_surface_chars = 50
+
+[keys]
+# Shift+Space で半角スペースを入力する。
+# true にすると、モードを問わず Shift+Space が半角スペースをコミットする
+# （Composing 中は現在のプリエディットを確定してから半角スペースを付ける）。
+# false（既定）では素の Space と同じ挙動のまま。
+shift_space_halfwidth = false

--- a/karukan-im/core/src/config/settings.rs
+++ b/karukan-im/core/src/config/settings.rs
@@ -21,6 +21,8 @@ pub struct Settings {
     pub conversion: ConversionSettings,
     /// Learning cache settings
     pub learning: LearningSettings,
+    /// Key-binding behavior settings
+    pub keys: KeysSettings,
 }
 
 /// Conversion strategy mode
@@ -83,6 +85,16 @@ pub struct LearningSettings {
     /// cache; longer conversion results (e.g. whole live-converted
     /// sentences) are not learned
     pub max_surface_chars: usize,
+}
+
+/// Key-binding behavior settings
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct KeysSettings {
+    /// Use Shift+Space to input a half-width ASCII space.
+    /// When true, Shift+Space commits a half-width space regardless of mode
+    /// (in Composing it first commits the current preedit, like Enter). When
+    /// false (default), Shift+Space keeps the bare-Space behavior.
+    pub shift_space_halfwidth: bool,
 }
 
 impl Default for Settings {
@@ -263,6 +275,31 @@ use_context = false
         let settings = Settings::load_from(&path).unwrap();
         assert_eq!(settings.conversion.num_candidates, 5);
         assert!(!settings.conversion.use_context);
+    }
+
+    #[test]
+    fn test_keys_default_shift_space_halfwidth_is_off() {
+        let settings = Settings::default();
+        assert!(!settings.keys.shift_space_halfwidth);
+    }
+
+    #[test]
+    fn test_keys_override_shift_space_halfwidth() {
+        let mut file = NamedTempFile::new().unwrap();
+        writeln!(
+            file,
+            r#"
+[keys]
+shift_space_halfwidth = true
+"#
+        )
+        .unwrap();
+
+        let path = file.path().to_path_buf();
+        let settings = Settings::load_from(&path).unwrap();
+        assert!(settings.keys.shift_space_halfwidth);
+        // Sections the user did not specify still fall back to defaults.
+        assert_eq!(settings.conversion.num_candidates, 9);
     }
 
     #[test]

--- a/karukan-im/core/src/core/engine/input.rs
+++ b/karukan-im/core/src/core/engine/input.rs
@@ -123,6 +123,22 @@ impl InputMethodEngine {
                 .with_action(EngineAction::UpdateAuxText(self.format_aux_composing()));
         }
 
+        // Shift+Space (opt-in via `shift_space_halfwidth`): commit a literal
+        // half-width ASCII space, regardless of mode. This overrides the
+        // bare-Space full-width behavior below so users have a dedicated
+        // gesture for a plain half-width space. Space has no shifted keysym
+        // variant, so the `shift_active` flag arrives reliably from both
+        // frontends. When the option is off, fall through to the bare-Space
+        // handling so the existing behavior is unchanged.
+        if self.config.shift_space_halfwidth
+            && shift_active
+            && key.keysym == Keysym::SPACE
+            && !key.modifiers.control_key
+            && !key.modifiers.alt_key
+        {
+            return EngineResult::consumed().with_action(EngineAction::Commit(" ".to_string()));
+        }
+
         // Bare Space from Empty state:
         //
         // * Hiragana mode → commit a full-width `　` directly, matching
@@ -245,6 +261,21 @@ impl InputMethodEngine {
                 Keysym::KEY_F | Keysym::KEY_F_UPPER => return self.move_caret_right(),
                 _ => {}
             }
+        }
+
+        // Shift+Space (opt-in via `shift_space_halfwidth`): commit the current
+        // preedit (like Enter) and append a half-width space, so the gesture
+        // yields a literal ASCII space instead of triggering conversion. Must
+        // precede the bare-Space conversion trigger in the match below. When
+        // the option is off, fall through so Shift+Space keeps triggering
+        // conversion like a bare Space.
+        if self.config.shift_space_halfwidth
+            && shift_active
+            && key.keysym == Keysym::SPACE
+            && !key.modifiers.control_key
+            && !key.modifiers.alt_key
+        {
+            return self.commit_composing_with_halfwidth_space();
         }
 
         match key.keysym {
@@ -412,6 +443,26 @@ impl InputMethodEngine {
             .with_action(EngineAction::Commit(text))
             .with_action(EngineAction::HideCandidates)
             .with_action(EngineAction::HideAuxText)
+    }
+
+    /// Commit the current composing text (identical to Enter) and append a
+    /// half-width ASCII space. Backs the Shift+Space gesture: the user always
+    /// ends up with a literal space after whatever was being composed. When
+    /// the buffer is empty, emits a bare space so the gesture still works.
+    pub(super) fn commit_composing_with_halfwidth_space(&mut self) -> EngineResult {
+        let mut result = self.commit_composing();
+        let appended = result.actions.iter_mut().any(|action| match action {
+            EngineAction::Commit(text) => {
+                text.push(' ');
+                true
+            }
+            _ => false,
+        });
+        if appended {
+            result
+        } else {
+            result.with_action(EngineAction::Commit(" ".to_string()))
+        }
     }
 
     /// Cancel the current input

--- a/karukan-im/core/src/core/engine/tests/basic.rs
+++ b/karukan-im/core/src/core/engine/tests/basic.rs
@@ -95,6 +95,78 @@ fn double_space_in_empty_hiragana_commits_two_fullwidth_spaces() {
 }
 
 #[test]
+fn shift_space_in_empty_commits_halfwidth_space_when_enabled() {
+    // With `shift_space_halfwidth` on, Shift+Space emits a literal half-width
+    // ASCII space regardless of mode — a deliberate override of the
+    // bare-Space full-width behavior.
+    let mut engine = InputMethodEngine::new();
+    engine.config.shift_space_halfwidth = true;
+    assert_eq!(engine.mode.current(), InputMode::Hiragana);
+
+    let result = engine.process_key(&press_shift(' '));
+    assert!(result.consumed);
+    assert!(matches!(engine.state(), InputState::Empty));
+    let committed = result.actions.iter().find_map(|a| match a {
+        EngineAction::Commit(t) => Some(t.clone()),
+        _ => None,
+    });
+    assert_eq!(committed.as_deref(), Some(" "));
+}
+
+#[test]
+fn shift_space_in_composing_commits_then_halfwidth_space_when_enabled() {
+    // With `shift_space_halfwidth` on, Shift+Space while composing commits the
+    // current preedit (like Enter) and appends a half-width space, then
+    // returns to Empty. It must NOT trigger conversion the way a bare Space
+    // does.
+    let mut engine = InputMethodEngine::new();
+    engine.config.shift_space_halfwidth = true;
+    engine.process_key(&press('a'));
+    engine.process_key(&press('i'));
+    assert_eq!(engine.preedit().unwrap().text(), "あい");
+
+    let result = engine.process_key(&press_shift(' '));
+    assert!(result.consumed);
+    assert!(matches!(engine.state(), InputState::Empty));
+    let committed = result.actions.iter().find_map(|a| match a {
+        EngineAction::Commit(t) => Some(t.clone()),
+        _ => None,
+    });
+    assert_eq!(committed.as_deref(), Some("あい "));
+}
+
+#[test]
+fn shift_space_off_by_default_keeps_fullwidth_in_empty() {
+    // Default config (`shift_space_halfwidth` off): Shift+Space in Empty
+    // Hiragana keeps the bare-Space behavior and commits a full-width `　`.
+    let mut engine = InputMethodEngine::new();
+    assert!(!engine.config.shift_space_halfwidth);
+
+    let result = engine.process_key(&press_shift(' '));
+    assert!(matches!(engine.state(), InputState::Empty));
+    let committed = result.actions.iter().find_map(|a| match a {
+        EngineAction::Commit(t) => Some(t.clone()),
+        _ => None,
+    });
+    assert_eq!(committed.as_deref(), Some("\u{3000}"));
+}
+
+#[test]
+fn shift_space_off_by_default_triggers_conversion_in_composing() {
+    // Default config (`shift_space_halfwidth` off): Shift+Space while composing
+    // keeps the bare-Space behavior and triggers conversion.
+    let mut engine = InputMethodEngine::new();
+    assert!(!engine.config.shift_space_halfwidth);
+    engine.process_key(&press('a'));
+    engine.process_key(&press('i'));
+    assert_eq!(engine.preedit().unwrap().text(), "あい");
+
+    let result = engine.process_key(&press_shift(' '));
+    assert!(result.consumed);
+    assert!(matches!(engine.state(), InputState::Conversion { .. }));
+}
+
+#[test]
 fn space_in_empty_katakana_passes_through() {
     // Non-Hiragana modes pass the bare Space through to the OS so the
     // application gets a normal half-width ASCII space.

--- a/karukan-im/core/src/core/engine/types.rs
+++ b/karukan-im/core/src/core/engine/types.rs
@@ -88,6 +88,9 @@ pub struct EngineConfig {
     pub strategy: StrategyMode,
     /// Whether live conversion is enabled at engine startup
     pub live_conversion: bool,
+    /// Whether Shift+Space inputs a half-width ASCII space.
+    /// When false, Shift+Space keeps the bare-Space behavior.
+    pub shift_space_halfwidth: bool,
 }
 
 impl EngineConfig {
@@ -108,6 +111,7 @@ impl EngineConfig {
             max_latency_ms: settings.conversion.max_latency_ms,
             strategy: settings.conversion.strategy,
             live_conversion: settings.conversion.live_conversion,
+            shift_space_halfwidth: settings.keys.shift_space_halfwidth,
         }
     }
 }
@@ -124,6 +128,7 @@ impl Default for EngineConfig {
             max_latency_ms: 100,
             strategy: StrategyMode::default(),
             live_conversion: false,
+            shift_space_halfwidth: false,
         }
     }
 }


### PR DESCRIPTION
## 背景

現在、スペース関連の入力は次の2つです。

- **素の Space**: ひらがなモードでは全角スペース `　` を確定、それ以外のモードでは OS へ素通し
- **Ctrl+Space**: 全角スペース `　`(U+3000) を入力。Empty からは全角スペースで composing を開始し、composing 中はカーソル位置に全角スペースを挿入

半角スペースを明示的に入力する手段がありません。日本語入力中に半角スペースを混ぜたい場面で、一度モードを切り替える必要があります。

## 参考にした挙動（Google 日本語入力 / ATOK）

出典は、Google 日本語入力については OSS 版 Mozc の実装と公式ヘルプ、ATOK については公式ドキュメントです（ATOK は proprietary のため、挙動はドキュメント記載に基づきます）。

### Google 日本語入力（Mozc）

公式ヘルプ「一般」に「スペースの入力」設定があり、次のように説明されています。

> スペースの全角、半角表示を変更することができます。

（出典: [Google 日本語入力ヘルプ「一般」](https://support.google.com/ime/japanese/answer/166764?hl=ja)）

OSS 版である Mozc（google/mozc）の実装では、この設定が `space_character_form` として定義されています。

```proto
enum FundamentalCharacterForm {
  FUNDAMENTAL_INPUT_MODE = 0; // follow the input mode
  FUNDAMENTAL_FULL_WIDTH = 1; // always FullWidth
  FUNDAMENTAL_HALF_WIDTH = 2; // always HalfWidth
}
optional FundamentalCharacterForm space_character_form = 47
  [default = FUNDAMENTAL_INPUT_MODE];
```

（出典: [google/mozc `src/protocol/config.proto`](https://github.com/google/mozc/blob/master/src/protocol/config.proto)）

スペースの全角/半角は「入力モードに従う（既定）/常に全角/常に半角」の3択で設定できます。加えて、半角に設定した状態では Shift+スペースで全角スペースが入る（＝通常設定の逆サイズになる）と参考記事で説明されています。（参考: [G-NOTE](https://316-jp.com/fullwidth-space) / [りんごびと](https://ringo-bito.com/entry/google-ime-space/)）

### ATOK（公式ドキュメント）

「スペースキーで入力する空白のサイズ」に **「入力文字種に従う」/「常に全角」/「常に半角」** の3択があります。さらに **Shift+スペース専用の設定**が用意されています。

> ［スペースバーで入力する空白文字の全角・半角］の［shift＋スペースバーの場合］で、（中略）shift＋スペースバーを押して、スペースバーで入力する空白文字のサイズとは逆のサイズの空白文字を入力できるように設定できます。

（出典: ATOK for Mac 公式 [スペースバーで入力する空白のサイズ（全角／半角）を設定する](https://atok.com/other/support/howtouse/mac/ev/pgs/ev_detail_space.htm) / JustSystems サポート [015066](https://support.justsystems.com/faq/1032/app/servlet/qadoc?QID=015066)）

つまり両者に共通する慣習は「**Shift+スペース = 通常スペースの逆サイズ（多くの設定で半角）**」です。karukan は素の Space（ひらがな）が全角なので、その逆の **半角**を Shift+Space に割り当てるのは、この慣習に沿っています。

## 提案する挙動（オプトイン設定）

先行 IME がスペース幅を設定で切り替えられるようにしているのに倣い、この挙動も**設定でオプトインする方式**にします。既存挙動を変える強い変更を既定で押し付けないためです。

設定 `[keys].shift_space_halfwidth`（既定 `false`）を追加します。

```toml
[keys]
# 既定 false。true のとき Shift+Space が半角スペースを入力する
shift_space_halfwidth = false
```

有効化したとき（`true`）の挙動:

- **Empty 状態**: モードを問わず半角スペース `" "` を直接コミット
- **Composing 状態**: 現在のプリエディットを Enter と同じように確定してから、そのうしろに半角スペースを1つ付ける（変換はトリガーしない）

無効時（既定 `false`）は Shift+Space が素の Space と同じ挙動のままで、**この PR による挙動変更はありません**。

Composing 状態で「確定してから半角スペース」とするのは、karukan では素の Space が変換トリガーを兼ねているための karukan 固有の調整です。Space にはシフト時の別 keysym 変種が無いため、`shift_key` フラグは macOS / fcitx5 いずれのフロントエンドからも確実に届きます。よってフロントエンド側の変更は不要で、共有エンジン（karukan-im）のみで完結します。

## 論点

- Shift+Space をこの用途（半角スペース）に割り当てて問題ないでしょうか（既存の割り当てや将来の予定と衝突しないか）。
- 既定 OFF のオプトイン設定という形にしています。設定キー名 `[keys].shift_space_halfwidth` と既定値はこれで良いでしょうか。
- 将来的に Mozc の `space_character_form` のように「スペース幅そのもの（入力モードに従う/全角/半角）」を設定化する方向も考えられますが、それは素の Space の挙動変更を伴うため本 PR ではスコープ外としています。
