### PR TITLE
変換候補選択中に Shift+Space で前候補に戻れるようにする

### DIFF
--- a/karukan-im/src/core/engine/conversion.rs
+++ b/karukan-im/src/core/engine/conversion.rs
@@ -578,6 +578,7 @@ impl InputMethodEngine {
         match key.keysym {
             Keysym::RETURN => self.commit_conversion(),
             Keysym::ESCAPE => self.cancel_conversion(),
+            Keysym::SPACE if key.modifiers.shift_key => self.prev_candidate(),
             Keysym::SPACE | Keysym::DOWN | Keysym::TAB => self.next_candidate(),
             Keysym::UP => self.prev_candidate(),
             Keysym::PAGE_DOWN => self.next_candidate_page(),

--- a/karukan-im/src/core/engine/tests/conversion.rs
+++ b/karukan-im/src/core/engine/tests/conversion.rs
@@ -45,6 +45,29 @@ fn test_conversion_char_commits_and_continues_romaji() {
 }
 
 #[test]
+fn test_shift_space_moves_to_prev_candidate() {
+    let mut engine = InputMethodEngine::new();
+
+    // Type "あ" and enter conversion
+    engine.process_key(&press('a'));
+    engine.process_key(&press_key(Keysym::SPACE));
+    assert!(matches!(engine.state(), InputState::Conversion { .. }));
+
+    // Space → next candidate
+    let result = engine.process_key(&press_key(Keysym::SPACE));
+    assert!(result.consumed);
+    assert!(matches!(engine.state(), InputState::Conversion { .. }));
+
+    // Shift+Space → prev candidate (should stay in conversion, not commit)
+    let result = engine.process_key(&press_shift_key(Keysym::SPACE));
+    assert!(result.consumed);
+    assert!(
+        matches!(engine.state(), InputState::Conversion { .. }),
+        "Shift+Space should navigate candidates, not commit"
+    );
+}
+
+#[test]
 fn test_alphabet_mode_space_inserts_literal_space() {
     let mut engine = InputMethodEngine::new();
 

--- a/karukan-im/src/core/engine/tests/mod.rs
+++ b/karukan-im/src/core/engine/tests/mod.rs
@@ -39,6 +39,10 @@ fn press_shift(ch: char) -> KeyEvent {
     )
 }
 
+fn press_shift_key(keysym: Keysym) -> KeyEvent {
+    KeyEvent::new(keysym, KeyModifiers::new().with_shift(true), true)
+}
+
 fn press_ctrl(keysym: Keysym) -> KeyEvent {
     KeyEvent::new(keysym, KeyModifiers::new().with_control(true), true)
 }


### PR DESCRIPTION
## 概要

変換候補の選択中に Shift+Space で前の候補に戻れるようにしました。
macOS 標準 IME や Google 日本語入力と同様の挙動です。

現状は Space / Down / Tab で次候補、Up / Ctrl+P で前候補に移動できますが、
Space で進んだ候補を戻すのに Up キーまで手を伸ばす必要がありました。

## 変更内容

`process_key_conversion` の Space マッチに Shift ガードを追加し、`prev_candidate()` を呼ぶようにしています（1行）。
Shift なしの Space は従来通り `next_candidate()` です。

テストも追加しています。