### PR TITLE
docs: パッケージからのインストール手順を追加（openSUSE / AUR / FreeBSD）

### DIFF
--- a/karukan-im/fcitx5/README.md
+++ b/karukan-im/fcitx5/README.md
@@ -6,6 +6,16 @@ Linux向け日本語IME（fcitx5アドオン）。[karukan-im](../core/) エン�
 
 ## Install
 
+### パッケージからインストール
+
+以下の環境ではパッケージが用意されています。インストール後は「[Prerequisites](#prerequisites)」以降のビルド手順は不要です。システム辞書のインストール（[dictionary.md](../../docs/dictionary.md)）と fcitx5-configtool での有効化は同じです。
+
+[![Packaging status](https://repology.org/badge/vertical-allrepos/karukan.svg)](https://repology.org/project/karukan/versions)
+
+- openSUSE Tumbleweed: `sudo zypper install fcitx5-karukan`
+- Arch Linux (AUR): [`karukan`](https://aur.archlinux.org/packages/karukan) / [`karukan-git`](https://aur.archlinux.org/packages/karukan-git)
+- FreeBSD: `pkg install ja-fcitx5-karukan`
+
 ### Prerequisites
 
 - [Rust](https://www.rust-lang.org/tools/install)

--- a/karukan-im/fcitx5/README.md
+++ b/karukan-im/fcitx5/README.md
@@ -8,7 +8,7 @@ Linux向け日本語IME（fcitx5アドオン）。[karukan-im](../core/) エン�
 
 ### パッケージからインストール
 
-以下の環境ではパッケージが用意されています。インストール後は「[Prerequisites](#prerequisites)」以降のビルド手順は不要です。システム辞書のインストール（[dictionary.md](../../docs/dictionary.md)）と fcitx5-configtool での有効化は同じです。
+以下の環境ではパッケージが用意されています。パッケージで入れた場合、「[Prerequisites](#prerequisites)」と「Build & Install」の手順は不要です。システム辞書のインストール（[dictionary.md](../../docs/dictionary.md)）と fcitx5-configtool での有効化は同じです。
 
 [![Packaging status](https://repology.org/badge/vertical-allrepos/karukan.svg)](https://repology.org/project/karukan/versions)
 


### PR DESCRIPTION
## 背景

karukan は現在いくつかのディストリビューションでパッケージ化されています。

- openSUSE Tumbleweed: [openSUSE:Factory/karukan](https://build.opensuse.org/package/show/openSUSE:Factory/karukan)（fcitx5 アドオンは `fcitx5-karukan`。メンテナは私です）
- Arch Linux: AUR の [karukan](https://aur.archlinux.org/packages/karukan) / [karukan-git](https://aur.archlinux.org/packages/karukan-git)
- FreeBSD: ports の [japanese/fcitx5-karukan](https://www.freshports.org/japanese/fcitx5-karukan/)

現状の README はソースからのビルド手順のみなので、パッケージで入れられることが分かるようにしたいです。

## 概要

`karukan-im/fcitx5/README.md` の Install 節の先頭に「パッケージからインストール」を追加し、[Repology](https://repology.org/project/karukan/versions) のバッジと各ディストリビューションのインストールコマンドを載せました。

## 補足

- openSUSE のパッケージは v0.1.0 タグを元にしています。新しいタグが切られればそれに追従して更新します。
- システム辞書（dict.tgz）は各パッケージに含まれていないので、辞書の手順はそのまま案内しています。
- Repology では FreeBSD の port が別プロジェクト名 `fcitx5-karukan` として登録されていましたが、統合ルールをマージしてもらったので（repology/repology-rules#1235）、反映後はバッジに FreeBSD も表示されます。
